### PR TITLE
v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 default-target = "wasm32-unknown-unknown"
 
 [features]
-default = []
 listener = []
 timer = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_web_keepalive"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Nulled"]
 edition = "2021"
 rust-version = "1.76"
@@ -11,14 +11,15 @@ keywords = ["bevy", "wasm", "web", "gamedev"]
 categories = ["game-development", "game-engines"]
 license = "MIT OR Apache-2.0"
 
+
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 default-target = "wasm32-unknown-unknown"
 
 [features]
-default = ["worker"]
+default = ["listener", "timer"]
 listener = []
-worker = []
 timer = []
 
 [dependencies]
@@ -28,8 +29,8 @@ bevy_time = "0.13.2"
 wasm-bindgen = "0.2.92"
 web-sys = { version = "0.3.69", features = [
     "Window",
-    "Document", 
+    "Document",
     "Worker",
     "Blob",
-    "Url"
+    "Url",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default-target = "wasm32-unknown-unknown"
 
 [features]
-default = ["listener", "timer"]
+default = []
 listener = []
 timer = []
 

--- a/README.md
+++ b/README.md
@@ -5,35 +5,39 @@
 
 Library of bevy plugins to keep a bevy app running in the browser despite despite not being visible
 
-### Background Worker Plugin
-The `BackgroundWorkerPlugin` plugin creates a web worker that runs the main schedule to keep bevy running in the background (eg. when the user is on another browser tab).
+## Background Worker Plugin
+
+The `WebKeepalivePlugin` plugin creates a web worker that runs the main schedule to keep bevy running in the background (eg. when the user is on another browser tab).
 
 Usage:
-```rs
+
+```rust
 // To add the worker, use add_plugins
-app.add_plugins(BackgroundWorkerPlugin::default())
+app.add_plugins(WebKeepalivePlugin::default())
 
 // Configure the worker like this:
-app.add_plugins(BackgroundWorkerPlugin {
+app.add_plugins(WebKeepalivePlugin {
     initial_wake_delay: 1000.0, // 1 sec delay
-    use_set_timeout: false, // use setInterval internally instead of setTimeout 
+    use_set_timeout: false, // use setInterval internally instead of setTimeout
 })
 
-// To change the wake_delay at run-time, access the `BackgroundWorker` resource in a system
-fn system_a(worker: Res<BackgroundWorker>) {
+// To change the wake_delay at run-time, access the `KeepaliveSettings` resource in a system
+fn system_a(worker: Res<KeepaliveSettings>) {
     worker.wake_delay = 16.667; // 60Hz updates
 }
 ```
 
 Reasoning: `bevy_winit` runs it's event loop via requestAnimationFrame. This works well for apps that don't need to run if they are in the background. However there are situations where this is unwanted such as multiplayer games that require a constant connection and cannot rely on reconnecting.
 
-Feature Requirements: `default-features` | `worker` 
+Feature Requirements: `default-features` | `worker`
 
-### Background Listener Plugin
+## Background Listener Plugin
+
 The `VisibilityChangeListenerPlugin` plugin registers a listener that fires whenever the app's visibility has changed and updates the `WindowVisibility` resource while also allowing the `Main` schedule to run a last time after the app is hidden.
 
 Usage:
-```rs
+
+```rust
 // To add the listener, use add_plugins
 app.add_plugins(VisibilityChangeListenerPlugin::default())
 
@@ -52,13 +56,16 @@ Reasoning: This may be used to notify internal or external services of user inac
 
 Feature Requirements: `listener`
 
-### Background Timer Plugin
-The `BackgroundTimerPlugin` plugin adds a utility resource which contains a timer that keeps track of time spent in the background. This plugin needs to be paired with the `BackgroundWorkerPlugin` to function properly (frame delta time is capped at 250ms in bevy_time by default)
+## Background Timer Plugin
+
+The `BackgroundTimerPlugin` plugin adds a utility resource which contains a timer that keeps track of time spent in the background. This plugin needs to be paired with the `WebKeepalivePlugin` to function properly (frame delta time is capped at 250ms in bevy_time by default)
 
 Usage:
-```rs
-// To add the listener, use add_plugins, please note that the BackgroundWorkerPlugin.initial_wake_delay should be < 250.0 so that we can ensure that the frame delta time won't be capped at 250ms 
-app.add_plugins((BackgroundWorkerPlugin::default(), BackgroundTimerPlugin))
+
+```rust
+
+// To add the listener, use add_plugins, please note that the WebKeepalivePlugin.initial_wake_delay should be < 250.0 so that we can ensure that the frame delta time won't be capped at 250ms 
+app.add_plugins((WebKeepalivePlugin::default(), BackgroundTimerPlugin))
 
 // To use the `BackgroundTimer` resource, access it in a system
 fn system_a(timer: Res<BackgroundTimer>) {

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Library of bevy plugins to keep a bevy app running in the browser despite despite not being visible
 
-## Background Worker Plugin
+## WebKeepalivePlugin
 
 The `WebKeepalivePlugin` plugin creates a web worker that runs the main schedule to keep bevy running in the background (eg. when the user is on another browser tab).
 
@@ -29,9 +29,7 @@ fn system_a(worker: Res<KeepaliveSettings>) {
 
 Reasoning: `bevy_winit` runs it's event loop via requestAnimationFrame. This works well for apps that don't need to run if they are in the background. However there are situations where this is unwanted such as multiplayer games that require a constant connection and cannot rely on reconnecting.
 
-Feature Requirements: `default-features` | `worker`
-
-## Background Listener Plugin
+## VisibilityChangeListenerPlugin
 
 The `VisibilityChangeListenerPlugin` plugin registers a listener that fires whenever the app's visibility has changed and updates the `WindowVisibility` resource while also allowing the `Main` schedule to run a last time after the app is hidden.
 
@@ -56,7 +54,7 @@ Reasoning: This may be used to notify internal or external services of user inac
 
 Feature Requirements: `listener`
 
-## Background Timer Plugin
+## BackgroundTimerPlugin
 
 The `BackgroundTimerPlugin` plugin adds a utility resource which contains a timer that keeps track of time spent in the background. This plugin needs to be paired with the `WebKeepalivePlugin` to function properly (frame delta time is capped at 250ms in bevy_time by default)
 
@@ -64,7 +62,7 @@ Usage:
 
 ```rust
 
-// To add the listener, use add_plugins, please note that the WebKeepalivePlugin.initial_wake_delay should be < 250.0 so that we can ensure that the frame delta time won't be capped at 250ms 
+// To add the listener, use add_plugins, please note that the WebKeepalivePlugin.initial_wake_delay should be < 250.0 so that we can ensure that the frame delta time won't be capped at 250ms
 app.add_plugins((WebKeepalivePlugin::default(), BackgroundTimerPlugin))
 
 // To use the `BackgroundTimer` resource, access it in a system

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ The `BackgroundTimerPlugin` plugin adds a utility resource which contains a time
 Usage:
 
 ```rust
-
 // To add the listener, use add_plugins, please note that the WebKeepalivePlugin.initial_wake_delay should be < 250.0 so that we can ensure that the frame delta time won't be capped at 250ms
 app.add_plugins((WebKeepalivePlugin::default(), BackgroundTimerPlugin))
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,16 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 #[cfg(feature = "listener")]
-pub mod background_listener;
-#[cfg(feature = "worker")]
-pub mod background_worker;
+mod background_listener;
+#[cfg(feature = "listener")]
+#[cfg_attr(docsrs, doc(cfg(feature = "listener")))]
+pub use background_listener::{VisibilityChangeListenerPlugin, WindowVisibility};
+
 #[cfg(feature = "timer")]
 pub mod background_timer;
+#[cfg(feature = "timer")]
+#[cfg_attr(docsrs, doc(cfg(feature = "timer")))]
+pub use background_timer::{BackgroundTimer, BackgroundTimerPlugin};
+
+mod background_worker;
+pub use background_worker::{KeepaliveSettings, WebKeepalivePlugin};


### PR DESCRIPTION
Changes

- Fixes all README doclints
- Fixes the erroneous use of `Arc<RwLock<World>>` in handling a type that is `!Send`
- Closes #2 - Docs.rs will specify the types that are feature-gated
- Refactored the `BackgroundWorkerPlugin`:
  - Renamed to `WebKeepalivePlugin`
  - Remove the `worker` feature. It is now always included.
  - Renamed `BackgroundWorker` to `KeepaliveSettings`