### PR TITLE
fix: module shouldn't be public, some docs updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_web_keepalive"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Nulled"]
 edition = "2021"
 rust-version = "1.76"

--- a/src/background_worker.rs
+++ b/src/background_worker.rs
@@ -8,7 +8,11 @@ use web_sys::{js_sys::Array, window, Blob, Url, Worker};
 /// This allows a game  to keep bevy running in the background (eg. when the user is on another browser tab).
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WebKeepalivePlugin {
-    /// Equivalent of frame delta time (milliseconds), eg. 60Hz = 16.667
+    /// The interval of time, in milliseconds, to run the `Main` schedule when a tab is hidden.
+    ///
+    /// This interval timer can be changed after the initial value is set through the [`KeepaliveSettings`] resource.
+    ///
+    /// The default is 16.667, or 60 updates per seconds.
     pub initial_wake_delay: f64,
     /// Use setTimeout instead of setInterval to enable changing the scheduler delay mid-run without clearing the interval
     pub use_set_timeout: bool,
@@ -44,7 +48,9 @@ impl Plugin for WebKeepalivePlugin {
 /// Please note that it currently isn't possible to change from `setTimeout` to `setInterval`.
 #[derive(Clone, Copy, Debug, PartialEq, Default, Resource)]
 pub struct KeepaliveSettings {
-    /// Equivalent of frame delta time (milliseconds), eg. 60Hz = 16.667
+    /// The interval of time, in milliseconds, to run the `Main` schedule when a tab is hidden.
+    ///
+    /// The default is 16.667, or 60 updates per seconds.
     pub wake_delay: f64,
 }
 

--- a/src/background_worker.rs
+++ b/src/background_worker.rs
@@ -4,8 +4,8 @@ use std::rc::Rc;
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};
 use web_sys::{js_sys::Array, window, Blob, Url, Worker};
 
-/// The `WebKeepalivePlugin` plugin creates a web worker that runs the main schedule every `scheduler_delay`
-/// to keep bevy running in the background (eg. when the user is on another browser tab).
+/// The `WebKeepalivePlugin` plugin creates a web worker that runs the main schedule even when the tab is not visible.
+/// This allows a game  to keep bevy running in the background (eg. when the user is on another browser tab).
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WebKeepalivePlugin {
     /// Equivalent of frame delta time (milliseconds), eg. 60Hz = 16.667

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ mod background_listener;
 pub use background_listener::{VisibilityChangeListenerPlugin, WindowVisibility};
 
 #[cfg(feature = "timer")]
-pub mod background_timer;
+mod background_timer;
 #[cfg(feature = "timer")]
 #[cfg_attr(docsrs, doc(cfg(feature = "timer")))]
 pub use background_timer::{BackgroundTimer, BackgroundTimerPlugin};


### PR DESCRIPTION
I accidentally kept one module public that didn't need to be. This fixes it.