### PR TITLE
Update to Bevy 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "bevy_web_keepalive"
 version = "0.5.0"
 authors = ["Nulled"]
 edition = "2021"
-rust-version = "1.89.0"
+rust-version = "1.95.0"
 description = "Bevy plugins to keep a bevy app running in the browser despite not being visible"
 readme = "README.md"
 repository = "https://github.com/Nul-led/bevy_web_keepalive"
@@ -21,10 +21,10 @@ listener = []
 timer = []
 
 [dependencies]
-bevy_winit = "0.18"
-bevy_app = "0.18"
-bevy_ecs = "0.18"
-bevy_time = "0.18"
+bevy_winit = "0.19.0"
+bevy_app = "0.19.0"
+bevy_ecs = "0.19.0"
+bevy_time = "0.19.0"
 wasm-bindgen = "0.2.104"
 web-sys = { version = "0.3.81", features = [
   "Window",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_web_keepalive"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Nulled"]
 edition = "2021"
 rust-version = "1.95.0"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@
 
 Library of bevy plugins to keep a bevy app running in the browser despite despite not being visible
 
+## Installation
+
+```toml
+[dependencies]
+bevy = "0.19"
+bevy_web_keepalive = "0.6"
+```
+
+## Bevy Compatibility
+
+| Bevy | bevy_web_keepalive |
+|------|--------------------|
+| 0.19 | 0.6                |
+| 0.18 | 0.5                |
+
 ## WebKeepalivePlugin
 
 The `WebKeepalivePlugin` plugin creates a web worker that runs the main schedule to keep bevy running in the background (eg. when the user is on another browser tab).


### PR DESCRIPTION
Updates bevy_web_keepalive for Bevy 0.19 and adds a small compatibility note.

Closes #25.

Checks:
- cargo test --all-features --all-targets --no-run
- cargo clippy --all-features --all-targets -- -D warnings