### PR TITLE
Fix hidden web worker updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_web_keepalive"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Nulled"]
 edition = "2021"
 rust-version = "1.95.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ listener = []
 timer = []
 
 [dependencies]
-bevy_winit = "0.19.0"
 bevy_app = "0.19.0"
 bevy_ecs = "0.19.0"
 bevy_time = "0.19.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,11 @@ listener = []
 timer = []
 
 [dependencies]
+bevy_winit = "0.19.0"
 bevy_app = "0.19.0"
 bevy_ecs = "0.19.0"
 bevy_time = "0.19.0"
+bevy_window = "0.19.0"
 wasm-bindgen = "0.2.104"
 web-sys = { version = "0.3.81", features = [
   "Window",

--- a/src/background_worker.rs
+++ b/src/background_worker.rs
@@ -8,15 +8,15 @@ use std::rc::Rc;
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};
 use web_sys::{js_sys::Array, window, Blob, Url, Worker};
 
-/// The `WebKeepalivePlugin` plugin creates a web worker that runs the main schedule even when the tab is not visible.
-/// This allows a game  to keep bevy running in the background (eg. when the user is on another browser tab).
+/// The `WebKeepalivePlugin` plugin creates a web worker that keeps Bevy updating even when the tab is not visible.
+/// This allows a game to keep Bevy running in the background (eg. when the user is on another browser tab).
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WebKeepalivePlugin {
-    /// The interval of time, in milliseconds, to run the `Main` schedule when a tab is hidden.
+    /// The interval of time, in milliseconds, to wake Bevy when a tab is hidden.
     ///
     /// This interval timer can be changed after the initial value is set through the [`KeepaliveSettings`] resource.
     ///
-    /// The default is 16.667, or 60 updates per seconds.
+    /// The default is 16.667, or 60 updates per second.
     pub wake_delay: f64,
 }
 
@@ -46,13 +46,13 @@ impl Plugin for WebKeepalivePlugin {
 /// Please note that it currently isn't possible to change from `setTimeout` to `setInterval`.
 #[derive(Clone, Debug, PartialEq, Default, Resource)]
 pub struct KeepaliveSettings {
-    /// The interval of time, in milliseconds, to run the `Main` schedule when a tab is hidden.
+    /// The interval of time, in milliseconds, to wake Bevy when a tab is hidden.
     ///
-    /// The default is 16.667, or 60 updates per seconds.
+    /// The default is 16.667, or 60 updates per second.
     pub wake_delay: f64,
 
     worker: Option<Worker>,
-    hidden_windows: Vec<(Entity, bool)>,
+    hidden_windows: Vec<Entity>,
 }
 
 // These are safe to implement as we are in a single threaded environment, they are only needed to satisfy bevy's trait requirements for resources
@@ -67,7 +67,7 @@ impl Drop for KeepaliveSettings {
     }
 }
 
-/// The `system_init_timeout_background_worker` system runs at `Startup` and launches the web worker with a tick loop based on `setInterval`
+/// The `system_init_background_worker` system runs at `Startup` and launches the web worker with a tick loop based on `setInterval`.
 fn system_init_background_worker(world: &mut World) {
     let mut settings = world.resource_mut::<KeepaliveSettings>();
     let script = Blob::new_with_str_sequence(
@@ -113,8 +113,12 @@ fn system_init_background_worker(world: &mut World) {
                     return;
                 }
 
-                if let Some(proxy) = world.get_resource::<EventLoopProxyWrapper>() {
-                    let _ = proxy.send_event(WinitUserEvent::WakeUp);
+                let sent = world
+                    .get_resource::<EventLoopProxyWrapper>()
+                    .is_some_and(|proxy| proxy.send_event(WinitUserEvent::WakeUp).is_ok());
+
+                if !sent {
+                    restore_windows_after_keepalive(world);
                 }
             }
         }
@@ -133,21 +137,16 @@ fn hide_windows_for_keepalive(world: &mut World) -> bool {
 
     let mut query = world.query::<(Entity, &mut Window)>();
     for (entity, mut window) in query.iter_mut(world) {
-        if !hidden_windows
-            .iter()
-            .any(|(hidden_entity, _)| *hidden_entity == entity)
-        {
-            hidden_windows.push((entity, window.visible));
+        if window.visible {
+            hidden_windows.push(entity);
+
+            // Bevy's winit runner performs a full App::update when all windows are invisible.
+            // Bypass change detection so this runner hint is not synced to the backend window.
+            window.bypass_change_detection().visible = false;
         }
-
-        // Bevy's winit runner performs a full App::update when all windows are invisible.
-        // Bypass change detection so this runner hint is not synced to the backend window.
-        window.bypass_change_detection().visible = false;
     }
 
-    if let Some(mut settings) = world.get_resource_mut::<KeepaliveSettings>() {
-        settings.hidden_windows = hidden_windows;
-    }
+    world.resource_mut::<KeepaliveSettings>().hidden_windows = hidden_windows;
 
     true
 }
@@ -163,9 +162,9 @@ fn restore_windows_after_keepalive(world: &mut World) {
     }
 
     let mut query = world.query::<&mut Window>();
-    for (entity, visible) in hidden_windows {
+    for entity in hidden_windows {
         if let Ok(mut window) = query.get_mut(world, entity) {
-            window.bypass_change_detection().visible = visible;
+            window.bypass_change_detection().visible = true;
         }
     }
 }

--- a/src/background_worker.rs
+++ b/src/background_worker.rs
@@ -1,6 +1,5 @@
-use bevy_app::{App, Plugin, Startup};
+use bevy_app::{App, Main, Plugin, Startup};
 use bevy_ecs::{resource::Resource, world::World};
-use bevy_winit::{EventLoopProxyWrapper, WinitUserEvent};
 use std::rc::Rc;
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};
 use web_sys::{js_sys::Array, window, Blob, Url, Worker};
@@ -100,9 +99,7 @@ fn system_init_background_worker(world: &mut World) {
                     return;
                 };
 
-                if let Some(proxy) = world.get_resource::<EventLoopProxyWrapper>() {
-                    let _ = proxy.send_event(WinitUserEvent::WakeUp);
-                }
+                world.run_schedule(Main);
             }
         }
     });

--- a/src/background_worker.rs
+++ b/src/background_worker.rs
@@ -1,5 +1,9 @@
-use bevy_app::{App, Main, Plugin, Startup};
-use bevy_ecs::{resource::Resource, world::World};
+use bevy_app::{App, First, Plugin, Startup};
+use bevy_ecs::{
+    change_detection::DetectChangesMut, entity::Entity, resource::Resource, world::World,
+};
+use bevy_window::Window;
+use bevy_winit::{EventLoopProxyWrapper, WinitUserEvent};
 use std::rc::Rc;
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};
 use web_sys::{js_sys::Array, window, Blob, Url, Worker};
@@ -29,9 +33,11 @@ impl Plugin for WebKeepalivePlugin {
         app.insert_resource(KeepaliveSettings {
             wake_delay: self.wake_delay,
             worker: None,
+            hidden_windows: Vec::new(),
         });
 
         app.add_systems(Startup, system_init_background_worker);
+        app.add_systems(First, restore_windows_after_keepalive);
     }
 }
 
@@ -46,6 +52,7 @@ pub struct KeepaliveSettings {
     pub wake_delay: f64,
 
     worker: Option<Worker>,
+    hidden_windows: Vec<(Entity, bool)>,
 }
 
 // These are safe to implement as we are in a single threaded environment, they are only needed to satisfy bevy's trait requirements for resources
@@ -88,18 +95,27 @@ fn system_init_background_worker(world: &mut World) {
     let closure = Closure::<dyn FnMut()>::new({
         let world = world_ptr.clone();
         move || {
-            if window()
+            let is_visible = window()
                 .and_then(|w| w.document())
-                .is_some_and(|d| !d.hidden())
-            {
-                return;
-            }
+                .is_some_and(|d| !d.hidden());
+
             unsafe {
                 let Some(world) = world.as_mut() else {
                     return;
                 };
 
-                world.run_schedule(Main);
+                if is_visible {
+                    restore_windows_after_keepalive(world);
+                    return;
+                }
+
+                if !hide_windows_for_keepalive(world) {
+                    return;
+                }
+
+                if let Some(proxy) = world.get_resource::<EventLoopProxyWrapper>() {
+                    let _ = proxy.send_event(WinitUserEvent::WakeUp);
+                }
             }
         }
     });
@@ -107,4 +123,49 @@ fn system_init_background_worker(world: &mut World) {
     worker.set_onmessage(Some(closure.as_ref().unchecked_ref()));
 
     closure.forget();
+}
+
+fn hide_windows_for_keepalive(world: &mut World) -> bool {
+    let Some(mut settings) = world.get_resource_mut::<KeepaliveSettings>() else {
+        return false;
+    };
+    let mut hidden_windows = std::mem::take(&mut settings.hidden_windows);
+
+    let mut query = world.query::<(Entity, &mut Window)>();
+    for (entity, mut window) in query.iter_mut(world) {
+        if !hidden_windows
+            .iter()
+            .any(|(hidden_entity, _)| *hidden_entity == entity)
+        {
+            hidden_windows.push((entity, window.visible));
+        }
+
+        // Bevy's winit runner performs a full App::update when all windows are invisible.
+        // Bypass change detection so this runner hint is not synced to the backend window.
+        window.bypass_change_detection().visible = false;
+    }
+
+    if let Some(mut settings) = world.get_resource_mut::<KeepaliveSettings>() {
+        settings.hidden_windows = hidden_windows;
+    }
+
+    true
+}
+
+fn restore_windows_after_keepalive(world: &mut World) {
+    let Some(mut settings) = world.get_resource_mut::<KeepaliveSettings>() else {
+        return;
+    };
+    let hidden_windows = std::mem::take(&mut settings.hidden_windows);
+
+    if hidden_windows.is_empty() {
+        return;
+    }
+
+    let mut query = world.query::<&mut Window>();
+    for (entity, visible) in hidden_windows {
+        if let Ok(mut window) = query.get_mut(world, entity) {
+            window.bypass_change_detection().visible = visible;
+        }
+    }
 }


### PR DESCRIPTION
Fixes #24.

Hidden web worker ticks now keep using Bevy's winit runner path instead of manually running the Main schedule.

Before sending WinitUserEvent::WakeUp while the document is hidden, the plugin temporarily marks Bevy windows as not visible so bevy_winit's existing all-invisible fallback performs a full App::update(). The temporary visibility change bypasses change detection so it is not synced to the backend window, and it is restored in First as soon as the update starts.

This keeps sub-app updates, extraction, tracker clearing, and AppExit handling on Bevy's normal runner path.

Also bumps the crate patch version to 0.6.1.

Verification:
- cargo check --target wasm32-unknown-unknown --all-features
- Bevy 0.18.1 browser repro: SUMMARY without_hidden_delta=0 with_hidden_delta=25 with_worker_onmessage_delta=25; VERDICT issue_reproduced=false
- Repro subapp advanced during hidden worker ticks.