### PR TITLE
Stop worker after pagehide and wasm panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,11 @@ wasm-bindgen = "0.2.104"
 web-sys = { version = "0.3.81", features = [
   "Window",
   "Document",
+  "ErrorEvent",
+  "Event",
+  "PromiseRejectionEvent",
   "Worker",
   "Blob",
   "Url",
+  "console",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ wasm-bindgen = "0.2.104"
 web-sys = { version = "0.3.81", features = [
   "Window",
   "Document",
-  "Event",
   "PageTransitionEvent",
   "Worker",
   "Blob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,8 @@ wasm-bindgen = "0.2.104"
 web-sys = { version = "0.3.81", features = [
   "Window",
   "Document",
-  "ErrorEvent",
   "Event",
-  "PromiseRejectionEvent",
+  "PageTransitionEvent",
   "Worker",
   "Blob",
   "Url",

--- a/src/background_worker.rs
+++ b/src/background_worker.rs
@@ -6,7 +6,7 @@ use bevy_window::Window;
 use bevy_winit::{EventLoopProxyWrapper, WinitUserEvent};
 use std::panic;
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};
-use web_sys::{console, js_sys::Array, window, Blob, Event, PageTransitionEvent, Url, Worker};
+use web_sys::{console, js_sys::Array, window, Blob, PageTransitionEvent, Url, Worker};
 
 /// The `WebKeepalivePlugin` plugin creates a web worker that keeps Bevy updating even when the tab is not visible.
 /// This allows a game to keep Bevy running in the background (eg. when the user is on another browser tab).
@@ -44,7 +44,7 @@ impl Plugin for WebKeepalivePlugin {
 /// The `KeepaliveSettings` resource can be used to control at runtime how the background worker operates.
 ///
 /// Please note that it currently isn't possible to change from `setTimeout` to `setInterval`.
-#[derive(Clone, Debug, PartialEq, Default, Resource)]
+#[derive(Debug, Default, Resource)]
 pub struct KeepaliveSettings {
     /// The interval of time, in milliseconds, to wake Bevy when a tab is hidden.
     ///
@@ -142,27 +142,20 @@ fn install_worker_cleanup(worker: Worker) {
         return;
     };
 
-    let closure = Closure::<dyn FnMut(Event)>::new(move |event: Event| {
-        let bfcache_pagehide = event
-            .dyn_ref::<PageTransitionEvent>()
-            .is_some_and(PageTransitionEvent::persisted);
-        if !bfcache_pagehide {
-            worker.terminate();
-        }
-    });
+    let closure =
+        Closure::<dyn FnMut(PageTransitionEvent)>::new(move |event: PageTransitionEvent| {
+            if !event.persisted() {
+                worker.terminate();
+            }
+        });
 
-    for event in ["pagehide", "unload"] {
-        if let Err(error) =
-            window.add_event_listener_with_callback(event, closure.as_ref().unchecked_ref())
-        {
-            console::warn_1(
-                &format!("bevy_web_keepalive: failed to install {event} worker cleanup: {error:?}")
-                    .into(),
-            );
-        }
+    match window.add_event_listener_with_callback("pagehide", closure.as_ref().unchecked_ref()) {
+        Ok(()) => closure.forget(),
+        Err(error) => console::warn_1(
+            &format!("bevy_web_keepalive: failed to install pagehide worker cleanup: {error:?}")
+                .into(),
+        ),
     }
-
-    closure.forget();
 }
 
 fn hide_windows_for_keepalive(world: &mut World) -> bool {

--- a/src/background_worker.rs
+++ b/src/background_worker.rs
@@ -4,12 +4,9 @@ use bevy_ecs::{
 };
 use bevy_window::Window;
 use bevy_winit::{EventLoopProxyWrapper, WinitUserEvent};
+use std::panic;
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};
-use web_sys::{
-    console,
-    js_sys::{Array, Error},
-    window, Blob, ErrorEvent, Event, PromiseRejectionEvent, Url, Worker,
-};
+use web_sys::{console, js_sys::Array, window, Blob, Event, PageTransitionEvent, Url, Worker};
 
 /// The `WebKeepalivePlugin` plugin creates a web worker that keeps Bevy updating even when the tab is not visible.
 /// This allows a game to keep Bevy running in the background (eg. when the user is on another browser tab).
@@ -131,6 +128,13 @@ fn system_init_background_worker(world: &mut World) {
 }
 
 fn install_worker_cleanup(worker: Worker) {
+    let worker_on_panic = worker.clone();
+    let previous_hook = panic::take_hook();
+    panic::set_hook(Box::new(move |info| {
+        worker_on_panic.terminate();
+        previous_hook(info);
+    }));
+
     let Some(window) = window() else {
         console::warn_1(
             &"bevy_web_keepalive: failed to install worker cleanup without a window".into(),
@@ -139,29 +143,15 @@ fn install_worker_cleanup(worker: Worker) {
     };
 
     let closure = Closure::<dyn FnMut(Event)>::new(move |event: Event| {
-        let should_terminate = match event.type_().as_str() {
-            "pagehide" | "beforeunload" | "unload" => true,
-            "error" => event.dyn_ref::<ErrorEvent>().is_some_and(|event| {
-                text_is_wasm_panic(&event.message()) || value_is_wasm_panic(&event.error())
-            }),
-            "unhandledrejection" => event
-                .dyn_ref::<PromiseRejectionEvent>()
-                .is_some_and(|event| value_is_wasm_panic(&event.reason())),
-            _ => false,
-        };
-
-        if should_terminate {
+        let bfcache_pagehide = event
+            .dyn_ref::<PageTransitionEvent>()
+            .is_some_and(PageTransitionEvent::persisted);
+        if !bfcache_pagehide {
             worker.terminate();
         }
     });
 
-    for event in [
-        "pagehide",
-        "beforeunload",
-        "unload",
-        "error",
-        "unhandledrejection",
-    ] {
+    for event in ["pagehide", "unload"] {
         if let Err(error) =
             window.add_event_listener_with_callback(event, closure.as_ref().unchecked_ref())
         {
@@ -173,19 +163,6 @@ fn install_worker_cleanup(worker: Worker) {
     }
 
     closure.forget();
-}
-
-fn value_is_wasm_panic(value: &JsValue) -> bool {
-    value
-        .as_string()
-        .is_some_and(|text| text_is_wasm_panic(&text))
-        || value
-            .dyn_ref::<Error>()
-            .is_some_and(|error| text_is_wasm_panic(&String::from(error.message())))
-}
-
-fn text_is_wasm_panic(text: &str) -> bool {
-    text.contains("unreachable") || text.contains("panicked at")
 }
 
 fn hide_windows_for_keepalive(world: &mut World) -> bool {

--- a/src/background_worker.rs
+++ b/src/background_worker.rs
@@ -4,9 +4,12 @@ use bevy_ecs::{
 };
 use bevy_window::Window;
 use bevy_winit::{EventLoopProxyWrapper, WinitUserEvent};
-use std::rc::Rc;
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};
-use web_sys::{js_sys::Array, window, Blob, Url, Worker};
+use web_sys::{
+    console,
+    js_sys::{Array, Error},
+    window, Blob, ErrorEvent, Event, PromiseRejectionEvent, Url, Worker,
+};
 
 /// The `WebKeepalivePlugin` plugin creates a web worker that keeps Bevy updating even when the tab is not visible.
 /// This allows a game to keep Bevy running in the background (eg. when the user is on another browser tab).
@@ -69,7 +72,7 @@ impl Drop for KeepaliveSettings {
 
 /// The `system_init_background_worker` system runs at `Startup` and launches the web worker with a tick loop based on `setInterval`.
 fn system_init_background_worker(world: &mut World) {
-    let mut settings = world.resource_mut::<KeepaliveSettings>();
+    let wake_delay = world.resource::<KeepaliveSettings>().wake_delay;
     let script = Blob::new_with_str_sequence(
         &Array::of1(&JsValue::from_str(&format!(
             "
@@ -81,45 +84,43 @@ fn system_init_background_worker(world: &mut World) {
                 interval = setInterval(() => self.postMessage(null), delay);
             }};
             ",
-            settings.wake_delay
+            wake_delay
         )))
         .unchecked_into(),
     )
     .unwrap();
 
     let worker = Worker::new(&Url::create_object_url_with_blob(&script).unwrap()).unwrap();
+    install_worker_cleanup(worker.clone());
 
-    settings.worker = Some(worker.clone()); // only clones the js heap ref
+    world.resource_mut::<KeepaliveSettings>().worker = Some(worker.clone());
 
-    let world_ptr = Rc::new(world as *mut World);
-    let closure = Closure::<dyn FnMut()>::new({
-        let world = world_ptr.clone();
-        move || {
-            let is_visible = window()
-                .and_then(|w| w.document())
-                .is_some_and(|d| !d.hidden());
+    let world = world as *mut World;
+    let closure = Closure::<dyn FnMut()>::new(move || {
+        let is_visible = window()
+            .and_then(|w| w.document())
+            .is_some_and(|d| !d.hidden());
 
-            unsafe {
-                let Some(world) = world.as_mut() else {
-                    return;
-                };
+        unsafe {
+            let Some(world) = world.as_mut() else {
+                return;
+            };
 
-                if is_visible {
-                    restore_windows_after_keepalive(world);
-                    return;
-                }
+            if is_visible {
+                restore_windows_after_keepalive(world);
+                return;
+            }
 
-                if !hide_windows_for_keepalive(world) {
-                    return;
-                }
+            if !hide_windows_for_keepalive(world) {
+                return;
+            }
 
-                let sent = world
-                    .get_resource::<EventLoopProxyWrapper>()
-                    .is_some_and(|proxy| proxy.send_event(WinitUserEvent::WakeUp).is_ok());
+            let sent = world
+                .get_resource::<EventLoopProxyWrapper>()
+                .is_some_and(|proxy| proxy.send_event(WinitUserEvent::WakeUp).is_ok());
 
-                if !sent {
-                    restore_windows_after_keepalive(world);
-                }
+            if !sent {
+                restore_windows_after_keepalive(world);
             }
         }
     });
@@ -127,6 +128,64 @@ fn system_init_background_worker(world: &mut World) {
     worker.set_onmessage(Some(closure.as_ref().unchecked_ref()));
 
     closure.forget();
+}
+
+fn install_worker_cleanup(worker: Worker) {
+    let Some(window) = window() else {
+        console::warn_1(
+            &"bevy_web_keepalive: failed to install worker cleanup without a window".into(),
+        );
+        return;
+    };
+
+    let closure = Closure::<dyn FnMut(Event)>::new(move |event: Event| {
+        let should_terminate = match event.type_().as_str() {
+            "pagehide" | "beforeunload" | "unload" => true,
+            "error" => event.dyn_ref::<ErrorEvent>().is_some_and(|event| {
+                text_is_wasm_panic(&event.message()) || value_is_wasm_panic(&event.error())
+            }),
+            "unhandledrejection" => event
+                .dyn_ref::<PromiseRejectionEvent>()
+                .is_some_and(|event| value_is_wasm_panic(&event.reason())),
+            _ => false,
+        };
+
+        if should_terminate {
+            worker.terminate();
+        }
+    });
+
+    for event in [
+        "pagehide",
+        "beforeunload",
+        "unload",
+        "error",
+        "unhandledrejection",
+    ] {
+        if let Err(error) =
+            window.add_event_listener_with_callback(event, closure.as_ref().unchecked_ref())
+        {
+            console::warn_1(
+                &format!("bevy_web_keepalive: failed to install {event} worker cleanup: {error:?}")
+                    .into(),
+            );
+        }
+    }
+
+    closure.forget();
+}
+
+fn value_is_wasm_panic(value: &JsValue) -> bool {
+    value
+        .as_string()
+        .is_some_and(|text| text_is_wasm_panic(&text))
+        || value
+            .dyn_ref::<Error>()
+            .is_some_and(|error| text_is_wasm_panic(&String::from(error.message())))
+}
+
+fn text_is_wasm_panic(text: &str) -> bool {
+    text.contains("unreachable") || text.contains("panicked at")
 }
 
 fn hide_windows_for_keepalive(world: &mut World) -> bool {


### PR DESCRIPTION
Closes #14.

This keeps the normal cleanup path in `KeepaliveSettings::drop`, and adds the two cases where that drop path may not run in the browser: a non-BFCache `pagehide` and a Rust wasm panic.

The page lifecycle path uses `PageTransitionEvent.persisted()`. BFCache navigations leave the worker alive so the page can resume normally. Final pagehide events terminate it. There is no `beforeunload` or `unload` listener.

The panic path uses Rust's panic hook instead of a window-level `error` listener, so an unrelated script error on the page does not kill the keepalive worker.

Repro guide I used:

1. Build a small Bevy web app with `WebKeepalivePlugin`.
2. Add a `panic_after` query parameter and panic from an `Update` system once the frame count reaches that value.
3. In the Playwright harness, wrap `window.Worker` before the app loads and count constructed workers, worker messages, `onmessage` calls, and `terminate()` calls.
4. Open the bundled app at `index.html?panic_after=25`.
5. Wait for the browser page error. Chromium reports the wasm panic as `unreachable` in this repro.
6. Wait another 1.5 seconds and compare the worker counters.

Before the fix, the app stopped at frame 25 but the worker kept posting messages:

```text
SUMMARY worker_messages_after_panic=15 worker_onmessage_after_panic=15
VERDICT issue_reproduced=true
```

With this fix, the worker is terminated by the panic hook and the counters stay flat:

```text
SUMMARY worker_messages_after_panic=0 worker_onmessage_after_panic=0 worker_terminate_calls=1
VERDICT issue_reproduced=false
```

I also added a lifecycle harness for the pagehide behavior:

```text
SUMMARY bfcache_terminate_calls=0 final_terminate_calls=2
VERDICT lifecycle_cleanup_passed=true
```

And reran the hidden-tab keepalive harness, including subapp frames so a main-schedule-only regression does not pass:

```text
SUMMARY without_hidden_delta=0 with_hidden_delta=25 with_worker_onmessage_delta=25 with_subapp_delta=25
VERDICT issue_reproduced=false
```

Checks run:

```text
cargo fmt --check
cargo check --target wasm32-unknown-unknown --all-features
cargo check --all-features
pnpm test:panic-worker
pnpm test:lifecycle-worker
pnpm test:keepalive
```