### PR TITLE
Add keepalive example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,12 @@ web-sys = { version = "0.3.81", features = [
   "Url",
   "console",
 ] }
+
+[dev-dependencies]
+bevy = { version = "0.19.0", default-features = false, features = [
+  "std",
+  "web",
+  "bevy_log",
+  "bevy_window",
+  "bevy_winit",
+] }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![crates.io](https://img.shields.io/crates/v/bevy_web_keepalive)](https://crates.io/crates/bevy_web_keepalive)
 [![docs.rs](https://docs.rs/bevy_web_keepalive/badge.svg)](https://docs.rs/bevy_web_keepalive)
 
-Library of bevy plugins to keep a bevy app running in the browser despite despite not being visible
+Library of Bevy plugins to keep a Bevy app running in the browser while the tab is hidden.
 
 ## Installation
 
@@ -20,9 +20,19 @@ bevy_web_keepalive = "0.6"
 | 0.19 | 0.6                |
 | 0.18 | 0.5                |
 
+## Examples
+
+Run the basic keepalive example in a browser:
+
+```sh
+bevy run --example keepalive web
+```
+
+The example logs a frame counter. Switch to another tab and the counter should keep advancing while the tab is hidden.
+
 ## WebKeepalivePlugin
 
-The `WebKeepalivePlugin` plugin creates a web worker that runs the main schedule to keep bevy running in the background (eg. when the user is on another browser tab).
+The `WebKeepalivePlugin` plugin creates a web worker that keeps Bevy updating in the background (eg. when the user is on another browser tab).
 
 Usage:
 
@@ -32,7 +42,7 @@ app.add_plugins(WebKeepalivePlugin::default())
 
 // Configure the worker like this:
 app.add_plugins(WebKeepalivePlugin {
-    initial_wake_delay: 1000.0, // 1 sec delay
+    wake_delay: 1000.0, // 1 sec delay
 })
 
 // To change the wake_delay at run-time, access the `KeepaliveSettings` resource in a system
@@ -46,7 +56,7 @@ fn system_b(world: &mut World) {
 }
 ```
 
-Reasoning: `bevy_winit` runs it's event loop via requestAnimationFrame. This works well for apps that don't need to run if they are in the background. However there are situations where this is unwanted such as multiplayer games that require a constant connection and cannot rely on reconnecting.
+Reasoning: `bevy_winit` runs its event loop via requestAnimationFrame. This works well for apps that don't need to run while they are in the background. However, there are situations where this is unwanted, such as multiplayer games that require a constant connection and cannot rely on reconnecting.
 
 ## VisibilityChangeListenerPlugin
 
@@ -63,7 +73,7 @@ app.add_plugins(VisibilityChangeListenerPlugin { run_main_schedule_on_hide: true
 
 // To use the `WindowVisibility` resource, access it in a system
 fn system_a(window_visibility: Res<WindowVisibility>) {
-    if !window_visibility.0 {
+    if window_visibility.is_hidden() {
         // Do something that you want to do whenever the window is hidden
     }
 }
@@ -80,12 +90,12 @@ The `BackgroundTimerPlugin` plugin adds a utility resource which contains a time
 Usage:
 
 ```rust
-// To add the listener, use add_plugins, please note that the WebKeepalivePlugin.initial_wake_delay should be < 250.0 so that we can ensure that the frame delta time won't be capped at 250ms
+// To add the timer, use add_plugins. The WebKeepalivePlugin wake_delay should be below 250ms so the frame delta time will not be capped at 250ms.
 app.add_plugins((WebKeepalivePlugin::default(), BackgroundTimerPlugin))
 
 // To use the `BackgroundTimer` resource, access it in a system
 fn system_a(timer: Res<BackgroundTimer>) {
-    if !timer.0.elapsed_secs() > 60.0 {
+    if timer.0.elapsed_secs() > 60.0 {
         // Clientside-timeout the user or something similar
     }
 }

--- a/examples/keepalive.rs
+++ b/examples/keepalive.rs
@@ -1,0 +1,43 @@
+use bevy::prelude::*;
+use bevy_web_keepalive::{KeepaliveSettings, WebKeepalivePlugin};
+
+#[derive(Resource, Default)]
+struct FrameCounter(u64);
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                title: "bevy_web_keepalive example".into(),
+                fit_canvas_to_parent: true,
+                ..default()
+            }),
+            ..default()
+        }))
+        .add_plugins(WebKeepalivePlugin { wake_delay: 100.0 })
+        .insert_resource(FrameCounter::default())
+        .add_systems(Startup, print_instructions)
+        .add_systems(Update, count_frames)
+        .run();
+}
+
+fn print_instructions(settings: Res<KeepaliveSettings>) {
+    info!(
+        "background worker running every {}ms while the browser tab is hidden",
+        settings.wake_delay
+    );
+    info!("open the browser console, switch tabs, and watch frames continue to advance");
+}
+
+fn count_frames(mut frames: ResMut<FrameCounter>, time: Res<Time>) {
+    frames.0 += 1;
+
+    if frames.0 == 1 || frames.0 % 60 == 0 {
+        info!(
+            "frame={} elapsed={:.1}s delta={:.3}s",
+            frames.0,
+            time.elapsed_secs(),
+            time.delta_secs()
+        );
+    }
+}

--- a/src/background_listener.rs
+++ b/src/background_listener.rs
@@ -33,6 +33,16 @@ impl Plugin for VisibilityChangeListenerPlugin {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Resource, Event)]
 pub struct WindowVisibility(bool);
 
+impl WindowVisibility {
+    pub fn is_visible(&self) -> bool {
+        self.0
+    }
+
+    pub fn is_hidden(&self) -> bool {
+        !self.0
+    }
+}
+
 /// The `system_init_active_background_listener` system initializes the visibilitychange listener which runs the `Main` schedule once when hidden
 fn system_init_active_background_listener(world: &mut World) {
     let world_ptr = Rc::new(world as *mut World);


### PR DESCRIPTION
Closes #4.

Adds a runnable `examples/keepalive.rs` browser example that installs `WebKeepalivePlugin`, logs the configured wake delay, and prints frame progress so users can switch tabs and see the app keep updating.

The README now uses Bevy CLI for the browser example:

```sh
bevy run --example keepalive web
```

Also fixes stale snippets while touching the docs:

- `initial_wake_delay` -> `wake_delay`
- invalid background timer condition
- `WindowVisibility` usage now uses `is_hidden()`

Checks run:

```text
cargo fmt --check
cargo check --all-features
cargo check --target wasm32-unknown-unknown --all-features
cargo check --target wasm32-unknown-unknown --examples --all-features
bevy build --yes --example keepalive web --bundle --bundle-dir target/keepalive-example-web
git diff --check
```