### PR TITLE
Bump patch version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_web_keepalive"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Nulled"]
 edition = "2021"
 rust-version = "1.95.0"


### PR DESCRIPTION
Bumps the crate version to `0.6.2` after the merged worker cleanup fix in #28.

Checks run:

```text
cargo fmt --check
cargo check --target wasm32-unknown-unknown --all-features
git diff --check
```